### PR TITLE
OPS-1307: Add GitHub Stale app config in all repos

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,26 @@
+# Configuration for GitHub Stale App - https://github.com/apps/stale
+# See also probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 20
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 10
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to [] to disable
+exemptLabels:
+  - pinned
+  - security
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to false to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when closing a stale issue. Set to false to disable
+closeComment: false


### PR DESCRIPTION
Adding config for the GitHub [Stale][1] app.

[1]: https://github.com/apps/stale
